### PR TITLE
Add a {{relative .url}} function

### DIFF
--- a/examples/06-basic-blog/src/blog/index.html
+++ b/examples/06-basic-blog/src/blog/index.html
@@ -11,7 +11,7 @@
 <ul>
 {{ range sorted .files.blog }}
 	{{ if .entry }}
-		<li><a href="{{ .url }}">{{ .title }}</a></li>
+		<li><a href="{{ relative .url }}">{{ .title }}</a></li>
 	{{ end }}
 {{ end }}
 </ul>

--- a/examples/06-basic-blog/src/index.html
+++ b/examples/06-basic-blog/src/index.html
@@ -7,7 +7,7 @@
 <h1>John Doe Internet Webpage</h1>
 
 <ul>
-<li><a href="/blog">My blog</a></li>
+<li><a href="./blog">My blog</a></li>
 </ul>
 
 </body>

--- a/examples/06-basic-blog/tgt/blog/index.html
+++ b/examples/06-basic-blog/tgt/blog/index.html
@@ -11,11 +11,11 @@
 	
 
 	
-		<li><a href="/blog/2013-01-15-second-blog-entry.html">My second blog entry</a></li>
+		<li><a href="2013/01/15/second-blog-entry.html">My second blog entry</a></li>
 	
 
 	
-		<li><a href="/blog/2013-01-02-first-entry.html">My first entry</a></li>
+		<li><a href="2013/01/02/first-entry.html">My first entry</a></li>
 	
 
 </ul>

--- a/examples/06-basic-blog/tgt/index.html
+++ b/examples/06-basic-blog/tgt/index.html
@@ -7,7 +7,7 @@
 <h1>John Doe Internet Webpage</h1>
 
 <ul>
-<li><a href="/blog">My blog</a></li>
+<li><a href="./blog">My blog</a></li>
 </ul>
 
 </body>

--- a/main.go
+++ b/main.go
@@ -215,6 +215,9 @@ func RenderTemplate(path string, input []byte, metadata map[string]interface{}) 
 		"importcss":  importcss,
 		"importjs":   importjs,
 		"sorted":     SortedValues,
+		"relative": func(s string) string {
+			return Relative(filepath.Dir(metadata["url"].(string)), s)
+		},
 	}
 
 	tmpl, err := template.New(templateName).Funcs(funcMap).Parse(string(input))


### PR DESCRIPTION
Old codebase! :)

The internal links are always absolute, which makes testing locally a bit annoying, since you need a webserver. This PR adds the function `relative` to the template system, so you can use relative links. Now you can simply browse the generated files.