### PR TITLE
also execute templates in markdown files

### DIFF
--- a/main.go
+++ b/main.go
@@ -159,8 +159,9 @@ func Transform(s StackReader) filepath.WalkFunc {
 			if v, ok := metadata["toc"]; ok && v.(bool) {
 				htmlBits |= blackfriday.HTML_TOC
 			}
+			md := RenderTemplate(path, contentBuf, metadata)
 			metadata = mergemap.Merge(metadata, map[string]interface{}{
-				"content": template.HTML(RenderMarkdown(contentBuf, htmlBits, extensionBits)),
+				"content": template.HTML(RenderMarkdown(md, htmlBits, extensionBits)),
 			})
 			templatePath, templateBuf := Template(s, path)
 			outputBuf := RenderTemplate(templatePath, templateBuf, metadata)


### PR DESCRIPTION
if you have markdown file you can't use Go templating in it. Now you can, which enables you to combine the `template' mechanism and listing entries.

For example, a file called `index.md`:

```
{
    "template": "../page.template",
    "entry": false
}
---
## My blog entries

<ul>
{{ range sorted .files.b }}
    {{ if .entry }}
        <li><a href="{{ relative .url }}">{{ .title }}</a></li>
    {{ end }}
{{ end }}
</ul>
```

(You can even generate markdown in the Go template...)